### PR TITLE
Bumb packages to fix dependecy warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "prettier": "^3.6.2",
                 "sass-embedded": "^1.92.1",
                 "typescript-eslint": "^8.43.0",
-                "vite": "^7.1.5",
+                "vite": "^7.2.7",
                 "vitest": "^3.2.4"
             }
         },
@@ -6800,9 +6800,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-            "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+            "version": "7.2.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
+            "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "prettier": "^3.6.2",
         "sass-embedded": "^1.92.1",
         "typescript-eslint": "^8.43.0",
-        "vite": "^7.1.5",
+        "vite": "^7.2.7",
         "vitest": "^3.2.4"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary 

This PR fixes some standing node_module install warnings for:

- `glob`
- `vite`
- `js-yaml`