### PR TITLE
:bug: Remove non-existent 'coverage' extra from tox config

### DIFF
--- a/django_prosemirror/schema/nodes/filer_image.py
+++ b/django_prosemirror/schema/nodes/filer_image.py
@@ -44,9 +44,9 @@ class FilerImageNode(NodeDefinition):
                 "getAttrs": lambda attrs: {
                     "src": attrs.get("src"),
                     "title": attrs.get("title"),
-                    "alt": attrs.get("alt"),
+                    "alt": attrs.get("alt", ""),
                     "imageId": attrs.get("imageId"),
-                    "caption": attrs.get("caption"),
+                    "caption": attrs.get("caption", ""),
                 },
             },
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ setenv =
     webkit: PLAYWRIGHT_BROWSER=webkit
 extras =
     tests
-    coverage
     !nofiler: images
 deps =
   django42: Django~=4.2.0


### PR DESCRIPTION
The tox.ini file was referencing a 'coverage' extra that doesn't exist in pyproject.toml, causing tox to fail with:

    extras not found for package maykin-django-prosemirror: coverage

The coverage functionality is already provided by pytest-cov which is included in the 'tests' extra, so the separate 'coverage' extra is unnecessary.

Also fixed #43 which was obscured by the failing pipeline.